### PR TITLE
:sparkles: Added getClusterExpansionZoom method

### DIFF
--- a/lib/src/fluster.dart
+++ b/lib/src/fluster.dart
@@ -150,6 +150,20 @@ class Fluster<T extends Clusterable> {
     return children;
   }
 
+  /// Returns the zoom on which the cluster expands into several children
+  /// (useful for "click to zoom" feature) given the cluster's clusterId.
+  int getClusterExpansionZoom(int clusterId) {
+    int expansionZoom = (clusterId % 32) - 1;
+    while (expansionZoom < this.maxZoom) {
+      final children = this.children(clusterId);
+      expansionZoom++;
+      if (children.length <= 0 ||
+          children.indexWhere((element) => !element.isCluster) != -1) break;
+      clusterId = children.first.clusterId;
+    }
+    return expansionZoom;
+  }
+
   /// Returns a list of standalone points (not clusters) that are children of
   /// the given cluster.
   List<T> points(int clusterId) {


### PR DESCRIPTION
### What changed

- added getClusterExpansionZoom() method from original supercluster algorithm